### PR TITLE
Fix dispose, decouple outer cancel from inner cancel

### DIFF
--- a/window-if-changed/src/main/java/com/jakewharton/rx/WindowGroupedObservable.java
+++ b/window-if-changed/src/main/java/com/jakewharton/rx/WindowGroupedObservable.java
@@ -15,15 +15,16 @@
  */
 package com.jakewharton.rx;
 
-import io.reactivex.Observer;
+import io.reactivex.*;
 import io.reactivex.observables.GroupedObservable;
 import io.reactivex.subjects.UnicastSubject;
 
 final class WindowGroupedObservable<K, T> extends GroupedObservable<K, T> {
-  final UnicastSubject<T> state = UnicastSubject.create();
+  final UnicastSubject<T> state;
 
-  WindowGroupedObservable(K key) {
+  WindowGroupedObservable(K key, Runnable onCancel) {
     super(key);
+    state = UnicastSubject.create(bufferSize(), onCancel);
   }
 
   @Override protected void subscribeActual(Observer<? super T> observer) {

--- a/window-if-changed/src/main/java/com/jakewharton/rx/WindowIfChangedObserver.java
+++ b/window-if-changed/src/main/java/com/jakewharton/rx/WindowIfChangedObserver.java
@@ -15,12 +15,17 @@
  */
 package com.jakewharton.rx;
 
+import java.util.concurrent.atomic.*;
+
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
 import io.reactivex.observables.GroupedObservable;
 
-final class WindowIfChangedObserver<T, K> implements Observer<T> {
+@SuppressWarnings("serial")
+final class WindowIfChangedObserver<T, K>
+extends AtomicInteger
+implements Observer<T>, Disposable, Runnable {
   private static final Object NOT_SET = new Object();
 
   private final Function<? super T, ? extends K> keySelector;
@@ -30,14 +35,21 @@ final class WindowIfChangedObserver<T, K> implements Observer<T> {
   private K key = (K) NOT_SET;
   private WindowGroupedObservable<K, T> window;
 
+  private Disposable d;
+
+  private final AtomicBoolean cancelled;
+
   WindowIfChangedObserver(Function<? super T, ? extends K> keySelector,
       Observer<? super GroupedObservable<K, T>> observer) {
     this.keySelector = keySelector;
     this.observer = observer;
+    this.cancelled = new AtomicBoolean();
+    this.lazySet(1);
   }
 
   @Override public void onSubscribe(Disposable d) {
-    observer.onSubscribe(d);
+    this.d = d;
+    observer.onSubscribe(this);
   }
 
   @Override public void onNext(T value) {
@@ -56,9 +68,12 @@ final class WindowIfChangedObserver<T, K> implements Observer<T> {
       if (window != null) {
         window.state.onComplete();
       }
-      this.key = nextKey;
-      this.window = window = new WindowGroupedObservable<>(nextKey);
-      observer.onNext(window);
+      if (!cancelled.get()) {
+          getAndIncrement();
+          this.key = nextKey;
+          this.window = window = new WindowGroupedObservable<>(nextKey, this);
+          observer.onNext(window);
+      }
     }
     window.state.onNext(value);
   }
@@ -85,5 +100,29 @@ final class WindowIfChangedObserver<T, K> implements Observer<T> {
     }
 
     observer.onComplete();
+  }
+
+  @Override public boolean isDisposed() {
+    return d.isDisposed();
+  }
+
+  @Override public void dispose() {
+    if (cancelled.compareAndSet(false, true)) {
+      if (decrementAndGet() == 0) {
+        this.key = null;
+        this.window = null;
+
+        d.dispose();
+      }
+    }
+  }
+
+  @Override public void run() {
+    if (decrementAndGet() == 0) {
+      this.key = null;
+      this.window = null;
+
+      d.dispose();
+    }
   }
 }


### PR DESCRIPTION
Fixes in this PR:

  - Operators on `Observable` should never send the upstream `Disposable` to downstream directly, even if the current operator doesn't add functionality around `dispose()` itself, otherwise operator fusion may break the flow in unexpected ways.
  - Calling dispose on the outer steam stopped delivering values to the inner windows which may lead to unexpected hangs. Conceptually, when one says `take(1)` on the operator, it means it wants exactly one window. That window is expected to deliver values until there's a key difference or that particular window gets disposed. This is how `groupBy` and `window` work in RxJava. The fix uses reference counting. 1 reference is the outer sequence getting disposed (once) and the other reference is the window itself. `UnicastSubject` calls a `Runnable` when it gets terminated or disposed (exactly once per instance). If the reference count reaches zero, the upstream is disposed only then.

Possible fixes not included:

  - When the main source calls `onError`, the current window is completed instead of calling `onError` on it. Other similar operators such as `groupBy` and `window` signal the same error to their groups/windows.
